### PR TITLE
Add codeclimate badges to README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![Code Climate](https://codeclimate.com/github/pbnl/pbnl-ldap-gui/badges/gpa.svg)](https://codeclimate.com/github/pbnl/pbnl-ldap-gui)
+[![Test Coverage](https://codeclimate.com/github/pbnl/pbnl-ldap-gui/badges/coverage.svg)](https://codeclimate.com/github/pbnl/pbnl-ldap-gui/coverage)
+[![Issue Count](https://codeclimate.com/github/pbnl/pbnl-ldap-gui/badges/issue_count.svg)](https://codeclimate.com/github/pbnl/pbnl-ldap-gui)
+
 A Symfony project created on August 1, 2016, 11:07 pm.
 
 Ein GUI für das PBNL-LDAP


### PR DESCRIPTION
We should use codeclimate to improve the code quality. The badges will
provide a direct link to the static code analysis on codeclimate.com.